### PR TITLE
Fix: Assert production and test classes are abstract or final

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
   "require-dev": {
     "codeclimate/php-test-reporter": "0.4.4",
     "localheinz/php-cs-fixer-config": "1.1.0",
-    "phpunit/phpunit": "^6.0.11"
+    "phpunit/phpunit": "^6.0.11",
+    "refinery29/test-util": "0.11.2"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "09e08f1c9f9d1f986842797e9e89b027",
+    "content-hash": "761a7b63afafb53e6830cb560a5ba20f",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -1724,6 +1724,61 @@
     ],
     "packages-dev": [
         {
+            "name": "beberlei/assert",
+            "version": "v2.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "reference": "8726e183ebbb0169cb6cb4832e22ebd355524563",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.1.1",
+                "phpunit/phpunit": "^4|^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Assert\\": "lib/Assert"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com",
+                    "role": "Collaborator"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "time": "2017-05-04T02:00:24+00:00"
+        },
+        {
             "name": "codeclimate/php-test-reporter",
             "version": "v0.4.4",
             "source": {
@@ -2034,6 +2089,54 @@
             ],
             "description": "A tool to automatically fix PHP code style",
             "time": "2017-04-25T20:50:30+00:00"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": []
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2016-04-29T12:21:54+00:00"
         },
         {
             "name": "guzzle/guzzle",
@@ -3065,6 +3168,62 @@
                 "xunit"
             ],
             "time": "2017-03-03T06:30:20+00:00"
+        },
+        {
+            "name": "refinery29/test-util",
+            "version": "0.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/refinery29/test-util.git",
+                "reference": "9174598d11a86870a6c4ac8986ec60065f623dc9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/refinery29/test-util/zipball/9174598d11a86870a6c4ac8986ec60065f623dc9",
+                "reference": "9174598d11a86870a6c4ac8986ec60065f623dc9",
+                "shasum": ""
+            },
+            "require": {
+                "beberlei/assert": "^2.7.3",
+                "fzaninotto/faker": "^1.5.1",
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-file": "^2.7.1"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "0.4.4",
+                "phpunit/phpunit": "^5.7.15",
+                "refinery29/php-cs-fixer-config": "0.6.15"
+            },
+            "suggest": {
+                "phpunit/phpunit": "If you want to make use of the assertions provided with the TestHelper"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Refinery29\\Test\\Util\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "andreas.moller@refinery29.com"
+                },
+                {
+                    "name": "R29 Product & Engineering",
+                    "email": "p.e@refinery29.com"
+                }
+            ],
+            "description": "Provides a test helper, generic data providers, and assertions.",
+            "keywords": [
+                "faker",
+                "test",
+                "util"
+            ],
+            "time": "2017-03-24T13:42:16+00:00"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -4262,6 +4421,108 @@
                 "validate"
             ],
             "time": "2016-11-23T20:04:58+00:00"
+        },
+        {
+            "name": "zendframework/zend-file",
+            "version": "2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-file.git",
+                "reference": "888fd4852432ee61ffd48a66b6812387b4f83c02"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-file/zipball/888fd4852432ee61ffd48a66b6812387b4f83c02",
+                "reference": "888fd4852432ee61ffd48a66b6812387b4f83c02",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-filter": "^2.6.1",
+                "zendframework/zend-i18n": "^2.6",
+                "zendframework/zend-progressbar": "^2.5.2",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-session": "^2.6.2",
+                "zendframework/zend-validator": "^2.6"
+            },
+            "suggest": {
+                "zendframework/zend-filter": "Zend\\Filter component",
+                "zendframework/zend-i18n": "Zend\\I18n component",
+                "zendframework/zend-validator": "Zend\\Validator component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\File\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-file",
+            "keywords": [
+                "file",
+                "zf2"
+            ],
+            "time": "2017-01-11T17:07:45+00:00"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/debedcfc373a293f9250cc9aa03cf121428c8e78",
+                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "^2.6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-stdlib",
+            "keywords": [
+                "stdlib",
+                "zf2"
+            ],
+            "time": "2016-09-13T14:38:50+00:00"
         }
     ],
     "aliases": [],

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Localheinz\GitHub\Pulse\Console;
 
 use Github\Client;
-use Localheinz\GitHub\Activity\Pulse;
+use Localheinz\GitHub\Pulse\Exception;
 use Localheinz\GitHub\Pulse\Repository;
 use Localheinz\GitHub\Pulse\Resource;
 use Symfony\Component\Console;
@@ -146,7 +146,7 @@ final class GenerateCommand extends Console\Command\Command
 
         try {
             $organization = $this->organizationRepository->find($input->getArgument('organization'));
-        } catch (Pulse\ResourceNotFoundException $exception) {
+        } catch (Exception\ResourceNotFoundException $exception) {
             $io->error(\sprintf(
                 'Organization "%s" could not be found',
                 $input->getArgument('organization')

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @link https://github.com/localheinz/github-pulse
  */
 
-namespace Localheinz\GitHub\Activity\Pulse;
+namespace Localheinz\GitHub\Pulse\Exception;
 
 interface ExceptionInterface
 {

--- a/src/Exception/ResourceNotFoundException.php
+++ b/src/Exception/ResourceNotFoundException.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @link https://github.com/localheinz/github-pulse
  */
 
-namespace Localheinz\GitHub\Activity\Pulse;
+namespace Localheinz\GitHub\Pulse\Exception;
 
 final class ResourceNotFoundException extends \RuntimeException implements ExceptionInterface
 {

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/github-pulse
+ */
+
+namespace Localheinz\GitHub\Pulse\Test\Unit;
+
+use PHPUnit\Framework;
+use Refinery29\Test\Util\TestHelper;
+
+final class ProjectCodeTest extends Framework\TestCase
+{
+    use TestHelper;
+
+    public function testProductionClassesAreAbstractOrFinal(): void
+    {
+        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../../src');
+    }
+
+    public function testTestClassesAreAbstractOrFinal(): void
+    {
+        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..');
+    }
+}


### PR DESCRIPTION
This PR

* [x] requires `refinery29/test-util`
* [x] asserts that production and test classes are `abstract` or `final`
* [x] fixes the namespace of exceptions