### PR TITLE
Fix: Actually run build against lowest and highest versions of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,9 @@ jobs:
 
       install:
         - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then composer remove --dev localheinz/php-cs-fixer-config; fi
-        - composer install
+        - if [[ "$WITH_LOWEST" == "true" ]]; then composer update --prefer-lowest; fi
+        - if [[ "$WITH_LOCKED" == "true" ]]; then composer install; fi
+        - if [[ "$WITH_HIGHEST" == "true" ]]; then composer update; fi
 
       script:
         - if [[ "$WITH_COVERAGE" == "true" ]]; then xdebug-enable; fi


### PR DESCRIPTION
This PR

* [x] ensures that we actually install lowest and highest versions of dependencies when corresponding environment variables are set on Travis CI